### PR TITLE
Fix ajaxSubmit (see #16)

### DIFF
--- a/src/ModalAjax.php
+++ b/src/ModalAjax.php
@@ -151,7 +151,7 @@ class ModalAjax extends Modal
             jQuery('#$id').kbModalAjax({
                 url: '$url',
                 size:'sm',
-                ajaxSubmit: $this->ajaxSubmit
+                ajaxSubmit: ".($this->ajaxSubmit ? "true" : "false")."
             });
         ");
     }

--- a/src/assets/js/kb-modal-ajax.js
+++ b/src/assets/js/kb-modal-ajax.js
@@ -36,7 +36,7 @@
     ModalAjax.prototype.init = function (options) {
         this.selector = options.selector || null;
         this.initalRequestUrl = options.url;
-        this.ajaxSubmit = options.ajaxSubmit || true;
+        this.ajaxSubmit = options.ajaxSubmit;
         jQuery(this.element).on('show.bs.modal', this.shown.bind(this));
     };
 


### PR DESCRIPTION
From #16 

This fixes the ajaxSubmit.

Your idea in #16 (ajaxSubmit: '$this->ajaxSubmit' does not work either, because in case on false, we also get an JS syntax error, because the resulting JS is:
```js
ajaxSubmit: 
});
```
which is invalid.
)

My PR generate either bool true or bool false inside the JS option, which does not need further testing (kbModal => options.ajaxSubmit || true).

Should fix the abilitity to diable ajaxSubmit now.

Let me know, if I forgot something.