### PR TITLE
check that the event is not triggered from bubble

### DIFF
--- a/src/assets/js/kb-modal-ajax.js
+++ b/src/assets/js/kb-modal-ajax.js
@@ -44,7 +44,7 @@
      * Requests the content of the modal and injects it, called after the
      * modal is shown
      */
-    ModalAjax.prototype.shown = function () {
+    ModalAjax.prototype.shown = function (event) {
         if (event.target != this.element) {
             return;
         }

--- a/src/assets/js/kb-modal-ajax.js
+++ b/src/assets/js/kb-modal-ajax.js
@@ -45,6 +45,9 @@
      * modal is shown
      */
     ModalAjax.prototype.shown = function () {
+        if (event.target != this.element) {
+            return;
+        }
 
         var self = this;
 


### PR DESCRIPTION
I investigated the problem and I find that this was happening from the bubbling event `show` from the kartik's widget.
I fixed the issue by adding the check that the event is sure targeted to the modal DOM node.